### PR TITLE
Added tests for team/league statistics methods to stat_tracker_test

### DIFF
--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -1,12 +1,13 @@
 require './test/test_helper'
 require './lib/stat_tracker'
+require 'mocha/minitest'
 
 class StatTrackerTest < Minitest::Test
 
   def setup
-    game_path = './data/games.csv'
+    game_path = './data/games_fixture.csv'
     team_path = './data/teams.csv'
-    game_teams_path = './data/game_teams.csv'
+    game_teams_path = './data/game_teams_fixture.csv'
 
     locations = {
       games: game_path,
@@ -17,45 +18,100 @@ class StatTrackerTest < Minitest::Test
   end
 
   def test_it_exists
-    game_path = './data/games.csv'
-    team_path = './data/teams.csv'
-    game_teams_path = './data/game_teams.csv'
-
-      locations = {
-        games: game_path,
-        teams: team_path,
-        game_teams: game_teams_path
-      }
-    stat_tracker = StatTracker.from_csv(locations)
-    assert_instance_of StatTracker, stat_tracker
+    assert_instance_of StatTracker, @stat_tracker
   end
 
   def test_has_attributes
-    game_path = './data/games.csv'
-    team_path = './data/teams.csv'
-    game_teams_path = './data/game_teams.csv'
-
-      locations = {
-        games: game_path,
-        teams: team_path,
-        game_teams: game_teams_path
-      }
-    stat_tracker = StatTracker.from_csv(locations)
-  
-
-    assert_equal  './data/games.csv', stat_tracker.games
-    assert_equal  './data/teams.csv', stat_tracker.teams
-    assert_equal  './data/game_teams.csv', stat_tracker.game_teams
+    assert_equal  './data/games_fixture.csv', @stat_tracker.games
+    assert_equal  './data/teams.csv', @stat_tracker.teams
+    assert_equal  './data/game_teams_fixture.csv', @stat_tracker.game_teams
+    assert_instance_of LeagueStatistics, @stat_tracker.league_statistics
+    assert_instance_of TeamStatistics, @stat_tracker.team_statistics
+    assert_instance_of GameStatistics, @stat_tracker.game_statistics
   end
 
-  def test_highest_total_score
-    stat_tracker.highest_total_score
-    stat_tracker.lowest_total_score
+  # def test_highest_total_score
+  #   stat_tracker.highest_total_score
+  #   stat_tracker.lowest_total_score
+  # end
+  #
+  # def test_lowest_total_score
+  #   stat_tracker.lowest_total_score
+  # end
+
+  def test_count_of_teams
+    assert_equal 32, @stat_tracker.league_statistics.count_of_teams
   end
 
-  def test_lowest_total_score
-    stat_tracker.lowest_total_score
+  def test_best_offense
+    @stat_tracker.league_statistics.stubs(:average_goals_by_team).returns({"1" => 1, "6" => 2.5, "3" => 2.2})
+    assert_equal "FC Dallas", @stat_tracker.league_statistics.best_offense
   end
 
+  def test_worst_offense
+    @stat_tracker.league_statistics.stubs(:average_goals_by_team).returns({"1" => 2.5, "6" => 2, "3" => 1.3})
+    expected = "Houston Dynamo"
+    assert_equal expected, @stat_tracker.league_statistics.worst_offense
+  end
+
+  def test_highest_scoring_visitor
+    assert_equal "FC Dallas", @stat_tracker.league_statistics.highest_scoring_visitor
+  end
+
+  def test_lowest_scoring_visitor
+    assert_equal "Sporting Kansas City", @stat_tracker.league_statistics.lowest_scoring_visitor
+  end
+
+  def test_highest_scoring_home_team
+    assert_equal "Real Salt Lake", @stat_tracker.league_statistics.highest_scoring_home_team
+  end
+
+  def test_lowest_scoring_home_team
+    assert_equal "Seattle Sounders FC", @stat_tracker.league_statistics.lowest_scoring_home_team
+  end
+
+  def test_team_info
+    expected1 = {"team_id" => "1", "franchise_id" => "23", "team_name" => "Atlanta United", "abbreviation" => "ATL", "link" => "/api/v1/teams/1"}
+    expected2 = {"team_id" => "4", "franchise_id" => "16", "team_name" => "Chicago Fire", "abbreviation" => "CHI", "link"=> "/api/v1/teams/4"}
+
+    assert_equal expected1, @stat_tracker.team_statistics.team_info("1")
+    assert_equal expected2, @stat_tracker.team_statistics.team_info("4")
+  end
+
+  def test_best_season
+      assert_equal "20132014", @stat_tracker.team_statistics.best_season("24")
+  end
+
+  def test_worst_season
+    assert_equal "20142015", @stat_tracker.team_statistics.worst_season("24")
+  end
+
+  def test_average_win_percentage
+    assert_equal 0.33, @stat_tracker.team_statistics.average_win_percentage("22")
+    assert_equal 0, @stat_tracker.team_statistics.average_win_percentage("3")
+    assert_equal 1, @stat_tracker.team_statistics.average_win_percentage("6")
+  end
+
+  def test_most_goals_scored
+    assert_equal 1, @stat_tracker.team_statistics.most_goals_scored("5")
+    assert_equal 2, @stat_tracker.team_statistics.most_goals_scored("3")
+    assert_equal 4, @stat_tracker.team_statistics.most_goals_scored("6")
+  end
+
+  def test_fewest_goals_scored
+    assert_equal 0, @stat_tracker.team_statistics.fewest_goals_scored("5")
+    assert_equal 1, @stat_tracker.team_statistics.fewest_goals_scored("3")
+    assert_equal 1, @stat_tracker.team_statistics.fewest_goals_scored("6")
+  end
+
+  def test_favorite_opponent
+    assert_equal "Houston Dynamo", @stat_tracker.team_statistics.favorite_opponent("6")
+    assert_equal "Philadelphia Union", @stat_tracker.team_statistics.favorite_opponent("22")
+  end
+
+  def test_rival
+    assert_equal "Washington Spirit FC", @stat_tracker.team_statistics.rival("24")
+    assert_equal "Orlando Pride", @stat_tracker.team_statistics.rival("17")
+  end
 
 end


### PR DESCRIPTION
I added the tests for the team/league statistics methods into the stat_tracker test file. I also changed the stat_tracker_test to use fixture files instead of the whole data set. I updated the attributes test to assert instances of LeagueStatistics, TeamStatistics, and GameStatistics. When season statistics are finished, that will need to be added too. Rspec still runs and passes all of the team/league statistics methods. 